### PR TITLE
preserve rotations after resizing

### DIFF
--- a/functions/image-processing/index.js
+++ b/functions/image-processing/index.js
@@ -52,7 +52,7 @@ exports.handler = async (event) => {
         var resizingOptions = {};
         if (operationsJSON['width']) resizingOptions.width = parseInt(operationsJSON['width']);
         if (operationsJSON['height']) resizingOptions.height = parseInt(operationsJSON['height']);
-        if (resizingOptions) transformedImage = sharpObject.resize(resizingOptions);
+        if (resizingOptions) transformedImage = sharpObject.resize(resizingOptions).rotate();
         // check if formatting is requested
         if (operationsJSON['format']) {
             var isLossy = false;

--- a/functions/image-processing/index.js
+++ b/functions/image-processing/index.js
@@ -52,7 +52,7 @@ exports.handler = async (event) => {
         var resizingOptions = {};
         if (operationsJSON['width']) resizingOptions.width = parseInt(operationsJSON['width']);
         if (operationsJSON['height']) resizingOptions.height = parseInt(operationsJSON['height']);
-        if (resizingOptions) transformedImage = sharpObject.resize(resizingOptions).rotate();
+        if (resizingOptions) transformedImage = sharpObject.rotate().resize(resizingOptions);
         // check if formatting is requested
         if (operationsJSON['format']) {
             var isLossy = false;


### PR DESCRIPTION
*Description of changes:*
Modify resize operation to also preserve rotations. Otherwise if the original image rotation [is stored in the EXIF data](https://zpl.fi/exif-orientation-in-different-formats/), the resized will not be oriented correctly.

See 
- https://sharp.pixelplumbing.com/api-operation
- https://stackoverflow.com/questions/48716266/sharp-image-library-rotates-image-when-resizing
