### PR TITLE
Pin Sharp for Node 16 compatibility.

### DIFF
--- a/lib/image-optimization-stack.ts
+++ b/lib/image-optimization-stack.ts
@@ -62,7 +62,6 @@ export class ImageOptimizationStack extends Stack {
     // For the bucket having original images, either use an external one, or create one with some samples photos.
     var originalImageBucket;
     var transformedImageBucket;
-    var sampleWebsiteDelivery;
 
     if (S3_IMAGE_BUCKET_NAME) {
       originalImageBucket = s3.Bucket.fromBucketName(this, 'imported-original-image-bucket', S3_IMAGE_BUCKET_NAME);
@@ -82,30 +81,6 @@ export class ImageOptimizationStack extends Stack {
         sources: [s3deploy.Source.asset('./image-sample')],
         destinationBucket: originalImageBucket,
         destinationKeyPrefix: 'images/rio/',
-      });
-      var sampleWebsiteBucket = new s3.Bucket(this, 's3-sample-website-bucket', {
-        removalPolicy: RemovalPolicy.DESTROY,
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        encryption: s3.BucketEncryption.S3_MANAGED,
-        enforceSSL: true,
-        autoDeleteObjects: true,
-      });
-
-      sampleWebsiteDelivery = new cloudfront.Distribution(this, 'websiteDeliveryDistribution', {
-        comment: 'image optimization - sample website',
-        defaultRootObject: 'index.html',
-        defaultBehavior: {
-          origin: new origins.S3Origin(sampleWebsiteBucket),
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        }
-      });
-      new CfnOutput(this, 'SampleWebsiteDomain', {
-        description: 'Sample website domain',
-        value: sampleWebsiteDelivery.distributionDomainName
-      });
-      new CfnOutput(this, 'SampleWebsiteS3Bucket', {
-        description: 'S3 bucket use by the sample website',
-        value: sampleWebsiteBucket.bucketName
       });
       new CfnOutput(this, 'OriginalImagesS3Bucket', {
         description: 'S3 bucket where original images are stored',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "image-optimization": "bin/image-optimization.js"
   },
   "scripts": {
-    "prebuild": "npm install sharp --prefix functions/image-processing/ --platform=linux --arch=x64",
+    "prebuild": "npm install sharp@0.32.6 --prefix functions/image-processing/ --platform=linux --arch=x64",
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",


### PR DESCRIPTION
*Description of changes:*

The latest version of the Sharp JS library does not support Node 16. This PR pins the Sharp library to the last version that supported Node 16, so that it can be deployed as-is.

Also removed the Sample Website deployment, as it is not necessary for the image optimization stack.
