### PR TITLE
Add sharp dependencies to npm prebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "image-optimization": "bin/image-optimization.js"
   },
   "scripts": {
-    "prebuild": "npm install sharp @img/sharp-libvips-linux-x64 @img/sharp-linux-x64 --prefix functions/image-processing --os=linux --cpu=x64 --force --omit=optional",
+    "prebuild": "npm install sharp @img/sharp-libvips-linux-x64 @img/sharp-linux-x64 --prefix functions/image-processing --force --omit=optional",
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "image-optimization": "bin/image-optimization.js"
   },
   "scripts": {
-    "prebuild": "npm install sharp --prefix functions/image-processing/ --os=linux --cpu=x64",
+    "prebuild": "npm install sharp @img/sharp-libvips-linux-x64 @img/sharp-linux-x64 --prefix functions/image-processing --os=linux --cpu=x64 --force --omit=optional",
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",


### PR DESCRIPTION
This PR will update how we the solution installs sharp and its dependencies by explicitly listing required libraries for x64 Lambda only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
