### PR TITLE
chore: align aws-cdk devDependency with aws-cdk-lib (2.189.1) to avoid schema mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "20.11.2",
     "@types/prettier": "2.7.3",
-    "aws-cdk": "2.121.1",
+    "aws-cdk": "2.189.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
This aligns the root package.json devDependency 'aws-cdk' with 'aws-cdk-lib' (2.189.1) to avoid CDK CLI/library schema mismatch as reported in https://github.com/aws-samples/image-optimization/issues/75

Fixes #75